### PR TITLE
Vagrant version issues

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant::Config.run do |config|
   # doesn't already exist on the user's system.
   config.vm.box_url = "http://files.vagrantup.com/precise32.box"
   config.vm.network :hostonly, "33.33.33.3"
-  config.vm.share_folder("v-root", "/vagrant", ".", :nfs => !RUBY_PLATFORM.downcase.include?("w32"))
+  config.vm.share_folder("vagrant-root", "/vagrant", ".", :nfs => !RUBY_PLATFORM.downcase.include?("w32"))
 
   config.vm.provision :chef_solo do |chef|
        chef.cookbooks_path = "cookbooks"


### PR DESCRIPTION
Fixed, issue where Vagrant was issuing warnings.

> There were warnings and/or errors while loading your Vagrantfile.
> Your Vagrantfile was written for an earlier version of Vagrant,
> and while Vagrant does the best it can to remain backwards
> compatible, there are some cases where things have changed
> significantly enough to warrant a message. These messages are
> shown below.
> 
> Warnings:
> - The 'v-root' shared folders have been renamed to 'vagrant-root'.
>   Assuming you meant 'vagrant-root'...
